### PR TITLE
[modify] サポートが切れたのでPython3に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ MAINTAINER innovatorjapan <system@innovator.jp.net>
 
 ARG version=1.14.69
 
-RUN apk -v --update add jq  python  py-pip  ca-certificates  \
-    && pip install awscli==${version} \
-    && apk -v --purge del py-pip \ 
+RUN apk -v --update add jq  python3  py3-pip  ca-certificates  \
+    && pip3 install awscli==${version} \
+    && apk -v --purge del py3-pip \ 
     &&  rm -rf /var/cache/apk/* 
 
 ADD aws-s3-deploy /bin


### PR DESCRIPTION
## 対応内容
2021年7月15日より、AWS CLIはPython 2.7のサポートをしなくなったので、Python 3.6.8を使用するように変更
https://aws.amazon.com/jp/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/