### PR TITLE
add apk update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER innovatorjapan <system@innovator.jp.net>
 
 ARG version=1.14.69
 
-RUN apk -v --update add curl jq  python3  py3-pip  ca-certificates  \
+RUN apk update \
+    && apk -v --update add curl jq  python3  py3-pip  ca-certificates  \
     && pip3 install awscli==${version} \
     && apk -v --purge del py3-pip \ 
     &&  rm -rf /var/cache/apk/* 


### PR DESCRIPTION
> Checking For JQ + CURL: Alpine
SLACK ORB ERROR: CURL is required. Please install.

が発生して失敗してしまう。確認すると

> 0b0795fc811c:~# apk add curl
WARNING: Ignoring APKINDEX.84815163.tar.gz: No such file or directory
WARNING: Ignoring APKINDEX.24d64ab1.tar.gz: No such file or directory
ERROR: unsatisfiable constraints:
  curl (missing):
    required by: world[curl]

というようなエラーが発生する。 `apk update` を実行してからだとinstallできたので追加した。